### PR TITLE
Support for running in an existing virtualenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 
 # python-support.nvim
 
-use `:PythonSupportInitPython2` and `:PythonSupportInitPython3` to initialize
-python support for neovim.
+Use `:PythonSupportInitPython2` and `:PythonSupportInitPython3` to initialize
+Python support for Neovim.
 
-If you like setup python for neovim manually, you may refer to [this
+If you like setup Python for Neovim manually, you may refer to [this
 wiki](https://github.com/zchee/deoplete-jedi/wiki/Setting-up-Python-for-Neovim)
 
 ## Requirements
@@ -14,10 +14,11 @@ wiki](https://github.com/zchee/deoplete-jedi/wiki/Setting-up-Python-for-Neovim)
 
 ## Usage
 
-execute `:PythonSupportInitPython2` and `:PythonSupportInitPython3`  after you
+Execute `:PythonSupportInitPython2` and `:PythonSupportInitPython3` after you
 have installed this plugin.
 
-This plugin automatically check python2 and python2 env for neovim. If you
+This plugin automatically checks if a python2 and/or python3 env is set up for Neovim.
+It uses a custom path for this under your Neovim configuration directory. If you
 don't need python2 or python3, use this to disable checking:
 
 ```vim
@@ -25,9 +26,9 @@ let g:python_support_python2_require = 0
 let g:python_support_python3_require = 0
 ```
 
-If you have extra need for python modules, let's say you need flake8
-installed, put this into your vimrc file. this plugin will check the
-requirements automatically, if requirements are not satisfied, a warning
+If you have extra need for Python modules, let's say you need flake8
+installed, put this into your vimrc file. This plugin will check the
+requirements automatically. If requirements are not satisfied, a warning
 message will be fired by this plugin. It should be fixed after you execute
 `PythonSupportInitPython2` or `PythonSupportInitPython3`.
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ wiki](https://github.com/zchee/deoplete-jedi/wiki/Setting-up-Python-for-Neovim)
 
 - For python2 support, you need python2 in your `$PATH`, with virtualenv installed
 - For python3 support, you need python3 in your `$PATH`
+- If Neovim is started in an active virtualenv, the Python version (and its requirements list, see below) are resolved dynamically, and the requirements installed.
 
 ## Usage
 
@@ -35,6 +36,13 @@ message will be fired by this plugin. It should be fixed after you execute
 ```vim
 let g:python_support_python3_requirements = add(get(g:,'python_support_python3_requirements',[]),'flake8')
 let g:python_support_python2_requirements = add(get(g:,'python_support_python2_requirements',[]),'flake8')
+```
+
+Alternatively
+
+```vim
+let s:py_reqs = ['jedi', 'flake8', 'isort', 'flake8-isort']
+let g:python_support_python3_requirements = extend(get(g:, 'python_support_python3_requirements', []), s:py_reqs)
 ```
 
 ## Notice

--- a/autoload/python_venv_setup.py
+++ b/autoload/python_venv_setup.py
@@ -13,7 +13,7 @@ try:
 except (DistributionNotFound, VersionConflict):
     import pip
 
-    args = ['install', '-v'] + dependencies
+    args = ['install', '-U', '-v'] + dependencies
 
     # Use 123 to tell neovim that a restart is needed, otherwise signal an error
     retval = pip.main(initial_args=args) or 123

--- a/autoload/python_venv_setup.py
+++ b/autoload/python_venv_setup.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+import sys
+import pkg_resources
+from pkg_resources import DistributionNotFound, VersionConflict
+
+dependencies = sys.argv[1:]
+
+try:
+    # here, if a dependency is not met, a DistributionNotFound or VersionConflict
+    # exception is thrown.
+    pkg_resources.require(dependencies)
+except (DistributionNotFound, VersionConflict):
+    import pip
+
+    args = ['install', '-v'] + dependencies
+
+    # Use 123 to tell neovim that a restart is needed, otherwise signal an error
+    retval = pip.main(initial_args=args) or 123
+
+    sys.exit(retval)
+

--- a/plugin/python_support.vim
+++ b/plugin/python_support.vim
@@ -24,7 +24,47 @@ func! s:python_support_init(v)
 	autocmd termclose  <buffer>  call s:init()
 endfunc
 
+""
+" Returns a bool-int to tell us if a virtual env is activated
+func! s:check_in_venv()
+	let l:venv = $VIRTUAL_ENV
+	return len(l:venv) > 0
+endfunc
+
+""
+" This should be called only when a virtualenv is in place
+" Ceases to work when Python is at version 10
+func! s:get_py_version()
+	let l:out = system('python -V')
+	let l:version = split(l:out)[1]
+
+	return l:version[0]
+endfunc
+
+""
+" Make sure the virtualenv is ok
+func! s:setup_venv(version)
+	if a:version == 2
+		let l:reqs = g:python_support_python2_requirements
+	else
+		let l:reqs = g:python_support_python3_requirements
+	endif
+	" Trust the virtualenv search path to use the correct Python executable
+	let l:cmd = ['python', split(globpath(&rtp,'autoload/python_venv_setup.py'),'\n')[0]] + l:reqs
+	call jobstart(l:cmd,{'on_stdout':function('s:on_stdout'), 'on_stderr':function('s:on_stdout'), 'on_exit':function('s:after_setup')})
+endfunc
+
+""
+" Main function
 func! s:init()
+
+	let l:in_venv = s:check_in_venv()
+	if l:in_venv
+		let l:version = s:get_py_version()
+		call s:setup_venv(l:version)
+		return
+	endif
+
 	com! PythonSupportInitPython2 call s:python_support_init(2)
 	com! PythonSupportInitPython3 call s:python_support_init(3)
 
@@ -72,6 +112,16 @@ endfunc
 
 func! s:on_stdout(job_id, data, event)
 	echom join(a:data,"\n")
+endfunc
+
+func! s:after_setup(job_id, retval, event)
+	if a:retval == 0
+		return
+	elseif a:retval == 123
+		echom 'RESTART NEOVIM NOW'
+	else
+		echom 'Check :messages - Setup failed with error ' . a:retval
+	endif
 endfunc
 
 call s:init()

--- a/plugin/python_support.vim
+++ b/plugin/python_support.vim
@@ -28,7 +28,7 @@ func! s:python_support_init(v)
 endfunc
 
 func! s:init()
-	
+
 	let l:python2 = ""
 	let l:python3 = ""
 
@@ -37,7 +37,7 @@ func! s:init()
 
 	if l:python2 != ''
 		let g:python_host_prog = l:python2
-		" span pyhton process to check requirements 1 second later
+		" spawn python process to check requirements 1 second later
 		call timer_start(1000,function('s:py2requirements'))
 	elseif s:python2_require
 		echom 'python2 not provided by python-support.nvim. Please execute PythonSupportInitPython2'
@@ -45,7 +45,7 @@ func! s:init()
 
 	if l:python3 != ''
 		let g:python3_host_prog = l:python3
-		" span pyhton process to check requirements 1 second later
+		" spawn python process to check requirements 1 second later
 		call timer_start(1000,function('s:py3requirements'))
 	elseif s:python3_require
 		echom 'python3 not provided by python-support.nvim. Please execute PythonSupportInitPython3'

--- a/plugin/python_support.vim
+++ b/plugin/python_support.vim
@@ -59,7 +59,7 @@ endfunc
 func! s:init()
 
 	let l:in_venv = s:check_in_venv()
-	if l:in_venv
+	if l:in_venv && (s:python2_require || s:python3_require)
 		let l:version = s:get_py_version()
 		call s:setup_venv(l:version)
 		return

--- a/plugin/python_support.vim
+++ b/plugin/python_support.vim
@@ -12,9 +12,6 @@ let g:python_support_python2_requirements = add(get(g:,'python_support_python2_r
 " let g:python_support_python3_requirements = add(get(g:,'python_support_python3_requirements',[]),'flake8')
 " let g:python_support_python2_requirements = add(get(g:,'python_support_python2_requirements',[]),'flake8')
 
-com! PythonSupportInitPython2 call s:python_support_init(2)
-com! PythonSupportInitPython3 call s:python_support_init(3)
-
 func! s:python_support_init(v)
 	split
 	enew
@@ -28,6 +25,8 @@ func! s:python_support_init(v)
 endfunc
 
 func! s:init()
+	com! PythonSupportInitPython2 call s:python_support_init(2)
+	com! PythonSupportInitPython3 call s:python_support_init(3)
 
 	let l:python2 = ""
 	let l:python3 = ""


### PR DESCRIPTION
Hi!

I sometimes wish I could be bothered to script the installation of my favorite Python development modules somewhere (the ones that aren't in every requirements.txt), but I don't know where would be the best place. I like your approach, but I always use separate virtualenvs for different projects. That's why I added this feature to your code.

Passed manual testing.

PS.
I didn't use the default shell-script mechanism you have because it doesn't work on ZSH (and because it's not what I do), but maybe this programmatic running of pip might give you ideas on how to implement that stuff in Python. I'm sure virtualenvs beside (obviously) pip can be called programmatically. Just an idea.

Thanks!