### PR TITLE
bugfix #10: install wheel before other packages in python3

### DIFF
--- a/autoload/python3_support.sh
+++ b/autoload/python3_support.sh
@@ -16,11 +16,14 @@ then
     rm -rf nvim_py3
     python3 -m venv nvim_py3
     . nvim_py3/bin/activate
+    pip install wheel
     pip install "$@"
 elif [ -n "$VIRTUAL_ENV" -a -f "$VIRTUAL_ENV/bin/python3" ]
 then
+    python3 -m pip install wheel
     python3 -m pip install "$@"
 else
+    python3 -m pip install --user wheel
     python3 -m pip install --user "$@"
 fi
 


### PR DESCRIPTION
Some package need wheel, installed it before other packages. This PR can fix #10.