### PR TITLE
Use the actual PIP package name

### DIFF
--- a/plugin/python_support.vim
+++ b/plugin/python_support.vim
@@ -10,8 +10,8 @@ let s:python3_require = get(g:,'python_support_python3_require',1)
 let g:python_support_python2_venv = get(g:,'python_support_python2_venv', 1)
 let g:python_support_python3_venv = get(g:,'python_support_python3_venv', 1)
 
-let g:python_support_python3_requirements = add(get(g:,'python_support_python3_requirements',[]),'neovim')
-let g:python_support_python2_requirements = add(get(g:,'python_support_python2_requirements',[]),'neovim')
+let g:python_support_python3_requirements = add(get(g:,'python_support_python3_requirements',[]),'pynvim')
+let g:python_support_python2_requirements = add(get(g:,'python_support_python2_requirements',[]),'pynvim')
 " let g:python_support_python3_requirements = add(get(g:,'python_support_python3_requirements',[]),'flake8')
 " let g:python_support_python2_requirements = add(get(g:,'python_support_python2_requirements',[]),'flake8')
 


### PR DESCRIPTION
The upstream package name is `pynvim`, not `neovim`. It's an alternative package name and therefore isn't the one returned by `pip freeze`. 
This PR does not change any of the functionality of this plugin.

See:
- https://github.com/neovim/pynvim/blob/master/setup.py#L35
- https://github.com/neovim/pynvim/commit/f2372385d1be6ed62ee458d5e017fff3541ce0f7

```bash
source ~/.local/share/nvim/vim-plug/python-support.nvim/autoload/nvim_py3/bin/activate
pip freeze | grep vim
# pynvim==0.4.0